### PR TITLE
Tried to downgrade docker client to v1.20.0

### DIFF
--- a/arenaserver/container/local-orchestrator.go
+++ b/arenaserver/container/local-orchestrator.go
@@ -8,7 +8,7 @@ import (
 	commonTypes "github.com/bytearena/bytearena/common/types"
 	"github.com/bytearena/bytearena/common/utils"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/client"
 )
 
 func getHostLocalOrch(orch *ContainerOrchestrator) (string, error) {

--- a/arenaserver/container/local-orchestrator.go
+++ b/arenaserver/container/local-orchestrator.go
@@ -57,6 +57,8 @@ func MakeLocalContainerOrchestrator(host string) ContainerOrchestrator {
 	cli, err := client.NewEnvClient()
 	utils.Check(err, "Failed to initialize docker client environment")
 
+	utils.Debug("orch", "docker client version: "+cli.ClientVersion())
+
 	registryAuth := ""
 
 	return ContainerOrchestrator{

--- a/arenaserver/container/orchestrator.go
+++ b/arenaserver/container/orchestrator.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/docker/distribution/reference"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/api/types/container"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/container"
+	"github.com/docker/docker/api/client"
 	uuid "github.com/satori/go.uuid"
 )
 

--- a/arenaserver/container/registry.go
+++ b/arenaserver/container/registry.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/bytearena/bytearena/common/utils"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/client"
 )
 
 func registryLogin(address string, ctx context.Context, client *client.Client) string {

--- a/arenaserver/container/remote-orchestrator.go
+++ b/arenaserver/container/remote-orchestrator.go
@@ -62,6 +62,8 @@ func MakeRemoteContainerOrchestrator(arenaAddr string, registryAddr string) Cont
 	cli, err := client.NewEnvClient()
 	utils.Check(err, "Failed to initialize docker client environment")
 
+	utils.Debug("orch", "docker client version: "+cli.ClientVersion())
+
 	registryAuth := registryLogin(registryAddr, ctx, cli)
 
 	return ContainerOrchestrator{

--- a/arenaserver/container/remote-orchestrator.go
+++ b/arenaserver/container/remote-orchestrator.go
@@ -9,7 +9,7 @@ import (
 	t "github.com/bytearena/bytearena/common/types"
 	"github.com/bytearena/bytearena/common/utils"
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
+	"github.com/docker/docker/api/client"
 )
 
 // TODO(jerome): parametrize this

--- a/cmd/arena-server/main.go
+++ b/cmd/arena-server/main.go
@@ -50,6 +50,9 @@ func main() {
 	// Make GraphQL client
 	graphqlclient := graphql.MakeClient(*apiurl)
 
+	// Make docker client
+	orch := container.MakeRemoteContainerOrchestrator(*arenaAddr, *registryAddr)
+
 	// Make message broker client
 	brokerclient, err := mq.NewClient(*mqhost)
 	utils.Check(err, "ERROR: Could not connect to messagebroker on "+*mqhost)
@@ -80,7 +83,6 @@ func main() {
 		arena, err := apiqueries.FetchGameById(graphqlclient, payload.Id)
 		utils.Check(err, "Could not fetch game "+payload.Id)
 
-		orch := container.MakeRemoteContainerOrchestrator(*arenaAddr, *registryAddr)
 		srv := arenaserver.NewServer(*host, *port, orch, arena, *arenaServerUUID, brokerclient)
 
 		srv.AddTearDownCall(func() error {

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,12 +7,6 @@ import:
   version: f86db6b22663a27ba4d278220b7e34be528b1e79
   subpackages:
   - reference
-- package: github.com/docker/docker
-  version: 82c2a08b6018586f3c8f35405c3bd6fce3c78ccd
-  subpackages:
-  - api/types
-  - api/types/container
-  - client
 - package: github.com/gorilla/handlers
   version: ~1.2.1
 - package: github.com/gorilla/mux


### PR DESCRIPTION
This version seems to have major breaking changes, still in WIP but looks like a waste of time:

```
[ERROR] Error scanning github.com/docker/distribution/digest: open /home/sven/.glide/cache/src/https-github.com-docker-distribution/digest: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
[ERROR] Error scanning github.com/docker/notary/tuf/store: open /home/sven/.glide/cache/src/https-github.com-docker-notary/tuf/store: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
[ERROR] Error scanning github.com/opencontainers/runc/libcontainer/label: open /home/sven/.glide/cache/src/https-github.com-opencontainers-runc/libcontainer/label: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
[ERROR] Error scanning github.com/docker/distribution/digest: open /home/sven/.glide/cache/src/https-github.com-docker-distribution/digest: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
[ERROR] Error scanning github.com/docker/notary/tuf/store: open /home/sven/.glide/cache/src/https-github.com-docker-notary/tuf/store: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
[ERROR] Error scanning github.com/opencontainers/runc/libcontainer/label: open /home/sven/.glide/cache/src/https-github.com-opencontainers-runc/libcontainer/label: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
[ERROR] Error scanning github.com/docker/docker/pkg/plugingetter: open /home/sven/.glide/cache/src/https-github.com-docker-docker/pkg/plugingetter: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
[ERROR] Error scanning github.com/docker/docker/api/types/network: open /home/sven/.glide/cache/src/https-github.com-docker-docker/api/types/network: no such file or directory
[ERROR] This error means the referenced package was not found.
[ERROR] Missing file or directory errors usually occur when multiple packages
[ERROR] share a common dependency and the first reference encountered by the scanner
[ERROR] sets the version to one that does not contain a subpackage needed required
[ERROR] by another package that uses the shared dependency. Try setting a
[ERROR] version in your glide.yaml that works for all packages that share this
[ERROR] dependency.
```