### PR TITLE
feat: add debug points mutation

### DIFF
--- a/game/deathmatch/SystemMutations.go
+++ b/game/deathmatch/SystemMutations.go
@@ -3,7 +3,6 @@ package deathmatch
 import (
 	json "encoding/json"
 	"errors"
-	"log"
 
 	"github.com/bytearena/bytearena/arenaserver/types"
 	"github.com/bytearena/bytearena/common/utils"
@@ -109,14 +108,24 @@ func handleSteerMutationMessage(deathmatch *DeathmatchGame, entityID ecs.EntityI
 	return nil
 }
 
-func handleDebugPointMutationMessage(deathmatch *DeathmatchGame, entityID ecs.EntityID, mutation types.AgentMessagePayloadMutation) error {
-	var debugPointFloats []float64
+func handleDebugPointMutationMessage(deathmatch *DeathmatchGame, entityID ecs.EntityID, mutation types.AgentMessagePayloadActions) error {
+	var debugPointFloats [2]float64
+
 	err := json.Unmarshal(mutation.GetArguments(), &debugPointFloats)
 	if err != nil {
-		return errors.New("Failed to unmarshal JSON arguments for steer mutation")
+		return errors.New("Failed to unmarshal JSON arguments for debug action")
 	}
 
-	log.Println(debugPointFloats)
+	renderQueryResult := deathmatch.getEntity(entityID, deathmatch.renderComponent)
+	if renderQueryResult != nil {
+		renderAspect := renderQueryResult.Components[deathmatch.renderComponent].(*Render)
+
+		// TODO(sven): find a better place to initial that
+		renderAspect.DebugPoints = make([][2]float64, 0)
+		renderAspect.DebugSegments = make([][2][2]float64, 0)
+
+		renderAspect.DebugPoints = append(renderAspect.DebugPoints, debugPointFloats)
+	}
 
 	return nil
 }

--- a/game/deathmatch/SystemMutations.go
+++ b/game/deathmatch/SystemMutations.go
@@ -3,6 +3,7 @@ package deathmatch
 import (
 	json "encoding/json"
 	"errors"
+	"log"
 
 	"github.com/bytearena/bytearena/arenaserver/types"
 	"github.com/bytearena/bytearena/common/utils"
@@ -53,6 +54,16 @@ func systemMutations(deathmatch *DeathmatchGame, mutations []types.AgentMutation
 			}
 		}
 
+		// 3. if any debug, communicate them
+		for _, mutation := range batch.Mutations {
+			switch mutation.GetMethod() {
+			case "debugpoint":
+				{
+					handleDebugPointMutationMessage(deathmatch, batch.AgentEntityId, mutation)
+				}
+			}
+		}
+
 	}
 }
 
@@ -94,6 +105,18 @@ func handleSteerMutationMessage(deathmatch *DeathmatchGame, entityID ecs.EntityI
 
 	steeringAspect := entityresult.Components[deathmatch.steeringComponent].(*Steering)
 	steeringAspect.PushSteer(steering)
+
+	return nil
+}
+
+func handleDebugPointMutationMessage(deathmatch *DeathmatchGame, entityID ecs.EntityID, mutation types.AgentMessagePayloadMutation) error {
+	var debugPointFloats []float64
+	err := json.Unmarshal(mutation.GetArguments(), &debugPointFloats)
+	if err != nil {
+		return errors.New("Failed to unmarshal JSON arguments for steer mutation")
+	}
+
+	log.Println(debugPointFloats)
 
 	return nil
 }

--- a/game/deathmatch/SystemPerception.go
+++ b/game/deathmatch/SystemPerception.go
@@ -417,35 +417,6 @@ func computeAgentVision(game *DeathmatchGame, entity *ecs.Entity, physicalAspect
 
 	vision = processOcclusions(vision, agentPosition)
 
-	renderQr := game.getEntity(entity.ID, game.renderComponent)
-	if renderQr != nil {
-		renderAspect := renderQr.Components[game.renderComponent].(*Render)
-		renderAspect.DebugPoints = make([][2]float64, 0)
-		renderAspect.DebugSegments = make([][2][2]float64, 0)
-		for _, v := range vision {
-
-			//absCenter := v.Center.SetAngle(v.Center.Angle() + agentOrientation).Add(agentPosition)
-			absNearEdge := v.NearEdge.SetAngle(v.NearEdge.Angle() + agentOrientation).Add(agentPosition)
-			absFarEdge := v.FarEdge.SetAngle(v.FarEdge.Angle() + agentOrientation).Add(agentPosition)
-
-			renderAspect.DebugPoints = append(renderAspect.DebugPoints,
-				absNearEdge.ToFloatArray(),
-				//absCenter.ToFloatArray(),
-				absFarEdge.ToFloatArray(),
-			)
-
-			renderAspect.DebugSegments = append(renderAspect.DebugSegments,
-				[2][2]float64{absNearEdge.ToFloatArray(), absFarEdge.ToFloatArray()},
-			)
-		}
-
-		renderAspect.DebugPoints = append(renderAspect.DebugPoints,
-			//agentPosition.ToFloatArray(),
-			leftVisionRelvec.Add(agentPosition).ToFloatArray(),
-			rightVisionRelvec.Add(agentPosition).ToFloatArray(),
-		)
-	}
-
 	//watch.Stop("global")
 	//fmt.Println(watch.String())
 

--- a/game/deathmatch/deathmatch.go
+++ b/game/deathmatch/deathmatch.go
@@ -476,14 +476,14 @@ func (deathmatch *DeathmatchGame) GetVizFrameJson() []byte {
 
 		msg.DebugPoints = append(msg.DebugPoints, scaledDebugPoints...)
 
-		scaledDebugSegments := make([][2][2]float64, len(renderAspect.DebugSegments))
-		for i := 0; i < len(renderAspect.DebugSegments); i++ {
-			scaledDebugSegments[i] = [2][2]float64{
-				vector.Vector2(renderAspect.DebugSegments[i][0]).Transform(deathmatch.physicalToAgentSpaceInverseTransform).ToFloatArray(),
-				vector.Vector2(renderAspect.DebugSegments[i][1]).Transform(deathmatch.physicalToAgentSpaceInverseTransform).ToFloatArray(),
-			}
-		}
-		msg.DebugSegments = append(msg.DebugSegments, scaledDebugSegments...)
+		// scaledDebugSegments := make([][2][2]float64, len(renderAspect.DebugSegments))
+		// for i := 0; i < len(renderAspect.DebugSegments); i++ {
+		// 	scaledDebugSegments[i] = [2][2]float64{
+		// 		vector.Vector2(renderAspect.DebugSegments[i][0]).Transform(deathmatch.physicalToAgentSpaceInverseTransform).ToFloatArray(),
+		// 		vector.Vector2(renderAspect.DebugSegments[i][1]).Transform(deathmatch.physicalToAgentSpaceInverseTransform).ToFloatArray(),
+		// 	}
+		// }
+		// msg.DebugSegments = append(msg.DebugSegments, scaledDebugSegments...)
 	}
 
 	res, _ := msg.MarshalJSON()

--- a/game/deathmatch/deathmatch.go
+++ b/game/deathmatch/deathmatch.go
@@ -467,14 +467,14 @@ func (deathmatch *DeathmatchGame) GetVizFrameJson() []byte {
 
 		msg.Objects = append(msg.Objects, obj)
 
-		// scaledDebugPoints := make([][2]float64, len(renderAspect.DebugPoints))
-		// for i := 0; i < len(renderAspect.DebugPoints); i++ {
-		// 	scaledDebugPoints[i] = vector.Vector2(renderAspect.DebugPoints[i]).
-		// 		Transform(deathmatch.physicalToAgentSpaceInverseTransform).
-		// 		ToFloatArray()
-		// }
+		scaledDebugPoints := make([][2]float64, len(renderAspect.DebugPoints))
+		for i := 0; i < len(renderAspect.DebugPoints); i++ {
+			scaledDebugPoints[i] = vector.Vector2(renderAspect.DebugPoints[i]).
+				Transform(deathmatch.physicalToAgentSpaceInverseTransform).
+				ToFloatArray()
+		}
 
-		// msg.DebugPoints = append(msg.DebugPoints, scaledDebugPoints...)
+		msg.DebugPoints = append(msg.DebugPoints, scaledDebugPoints...)
 
 		scaledDebugSegments := make([][2][2]float64, len(renderAspect.DebugSegments))
 		for i := 0; i < len(renderAspect.DebugSegments); i++ {


### PR DESCRIPTION
Closes https://github.com/ByteArena/bytearena/issues/238

# Feature

New API mutation method: debugpoint.

# Note

- It's a mutation because `agent.takeActions` send mutations (or should we figure out a special debug method?)
- Should we handle this in dedicated system which add the info for the get viz message later?